### PR TITLE
added PoseStamped publishers for each tracked object

### DIFF
--- a/simtrack_nodes/CMakeLists.txt
+++ b/simtrack_nodes/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   message_generation
   tf
+  geometry_msgs
   interface
 )
 
@@ -40,7 +41,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
   DEPENDS cv_bridge
-  CATKIN_DEPENDS image_transport tf message_runtime interface
+  CATKIN_DEPENDS image_transport tf geometry_msgs message_runtime interface
 )
 
 # show additional files in qtcreator

--- a/simtrack_nodes/include/simtrack_nodes/multi_rigid_node.h
+++ b/simtrack_nodes/include/simtrack_nodes/multi_rigid_node.h
@@ -46,6 +46,7 @@
 #include <sensor_msgs/Image.h>
 #include <std_msgs/Int32.h>
 #include <tf/transform_broadcaster.h>
+#include <geometry_msgs/PoseStamped.h>
 #include <multi_rigid_tracker.h>
 #include <multi_rigid_detector.h>
 #include <dynamic_reconfigure/server.h>
@@ -156,6 +157,7 @@ private:
   boost::shared_ptr<image_transport::ImageTransport> debug_img_it_;
   image_transport::Publisher debug_img_pub_;
   tf::TransformBroadcaster tfb_;
+  std::map<std::string, ros::Publisher> pose_publishers_;
 
   // Subscriptions
   ros::Subscriber sub_detector_pose_;

--- a/simtrack_nodes/package.xml
+++ b/simtrack_nodes/package.xml
@@ -15,6 +15,7 @@
   <build_depend>cv_bridge</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>geometry_msgs</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>eigen</build_depend>
@@ -23,6 +24,7 @@
   <run_depend>image_transport</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>geometry_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>interface</run_depend>
 

--- a/simtrack_nodes/src/multi_rigid_node.cpp
+++ b/simtrack_nodes/src/multi_rigid_node.cpp
@@ -41,7 +41,6 @@
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <simtrack_nodes/multi_rigid_node.h>
-#include <tf/transform_datatypes.h>
 #include <windowless_gl_context.h>
 #undef Success
 #include <Eigen/Geometry>
@@ -135,7 +134,7 @@ MultiRigidNode::MultiRigidNode(ros::NodeHandle nh)
   for (auto &it : model_names) {
     objects_.push_back(composeObjectInfo(it));
     obj_filenames_.push_back(composeObjectFilename(it));
-    pose_publishers_[it] = nh.advertise<geometry_msgs::PoseStamped>("/simtrack/"+it, 1);;
+    pose_publishers_[it] = nh.advertise<geometry_msgs::PoseStamped>("/simtrack/"+it, 1);
   }
 
   // get optical flow parameters


### PR DESCRIPTION
Publishes each tracked object's pose in the **/simtrack/<model_name>** topic in a PoseStamped message. This allows tf-independent tracking which can speed things up in some applications.
