### PR TITLE
Add explicit include to <numeric> for c+14 and melodic

### DIFF
--- a/interface/src/cmd_line_generate_sift_model.cpp
+++ b/interface/src/cmd_line_generate_sift_model.cpp
@@ -45,6 +45,7 @@
 #include <utility_kernels_pose.h>
 #include <utilities.h>
 #include <utility_kernels.h>
+#include <numeric>
 
 int main(int argc, char **argv) {
 

--- a/interface/src/multi_rigid_tracker.cpp
+++ b/interface/src/multi_rigid_tracker.cpp
@@ -38,6 +38,7 @@
 #include <utility_kernels.h>
 #include <utility_kernels_pose.h>
 #include <hdf5.h>
+#include <numeric>
 
 using namespace util;
 

--- a/pose_estimation/src/d_multiple_rigid_pose_sparse.cpp
+++ b/pose_estimation/src/d_multiple_rigid_pose_sparse.cpp
@@ -40,6 +40,7 @@
 #include <utilities.h>
 #include <Eigen/Dense>
 #include <opencv2/calib3d/calib3d.hpp>
+#include <numeric>
 
 namespace pose {
 

--- a/simtrack_nodes/src/multi_rigid_node.cpp
+++ b/simtrack_nodes/src/multi_rigid_node.cpp
@@ -47,6 +47,7 @@
 #include <translation_rotation_3d.h>
 #include <hdf5_file.h>
 #include <utilities.h>
+#include <numeric>
 
 using namespace util;
 

--- a/simtrack_nodes/src/pr2_cam_switch_node.cpp
+++ b/simtrack_nodes/src/pr2_cam_switch_node.cpp
@@ -46,6 +46,7 @@
 #include <translation_rotation_3d.h>
 #include <hdf5_file.h>
 #include <utilities.h>
+#include <numeric>
 
 using namespace util;
 


### PR DESCRIPTION
I had to add `#include <numeric>` to be able to compile on melodic and Ubuntu 18.04.
Maybe caused by the use of c++14 ?

Works now on melodic anyway !